### PR TITLE
Call frombytes instead of fromstring

### DIFF
--- a/qrencode/__init__.py
+++ b/qrencode/__init__.py
@@ -48,7 +48,7 @@ def encode(data, version=0, level=QR_ECLEVEL_L, hint=QR_MODE_8,
     else:
         version, size, data = _encode(data, version, level, hint, False)
     
-    im = Image.fromstring('L', (size, size), data)
+    im = Image.frombytes('L', (size, size), data)
     return (version, size, im)
 
 def encode_scaled(data, size, version=0, level=QR_ECLEVEL_L, hint=QR_MODE_8,


### PR DESCRIPTION
`Image.fromstring()` was removed in Pillow in version 3, see
https://pillow.readthedocs.io/en/3.0.x/releasenotes/3.0.0.html#deprecated-methods

This fixes https://bugs.launchpad.net/qreator/+bug/1573577 and similar bugs in other packages.